### PR TITLE
Added "Local Path" option in connection dialog. This enables us to up…

### DIFF
--- a/html/dialog_connection.html
+++ b/html/dialog_connection.html
@@ -33,6 +33,9 @@
 					<tr><th>{{MyStrings.TXT_CONNECTION_PASSWORD}}</th><td>
 						<input type="password" class="input-password"/>
 					</td></tr>
+					<tr><th>{{MyStrings.TXT_CONNECTION_LOCAL_PATH}}</th><td>
+						<input type="text" class="input-local-path"/>
+					</td></tr>
 					<tr><th>{{MyStrings.TXT_CONNECTION_SERVER_PATH}}</th><td>
 						<input type="text" class="input-server-path"/>
 					</td></tr>
@@ -60,6 +63,9 @@
 					</td></tr>
 					<tr><th>{{MyStrings.TXT_CONNECTION_PASSWORD}}</th><td>
 						<input type="password" class="input-password-p"/>
+					</td></tr>
+					<tr><th>{{MyStrings.TXT_CONNECTION_LOCAL_PATH}}</th><td>
+						<input type="text" class="input-local-path-p"/>
 					</td></tr>
 					<tr><th>{{MyStrings.TXT_CONNECTION_SERVER_PATH}}</th><td>
 						<input type="text" class="input-server-path-p"/>

--- a/modules/ConnectionSettingManager.js
+++ b/modules/ConnectionSettingManager.js
@@ -39,6 +39,7 @@ define(function(require) {
 		$dialog_connection.find('.input-username').val(settings.username);
 		$dialog_connection.find('.input-rsa-path').val(settings.rsaPath);
 		$dialog_connection.find('.input-password').val(settings.password);
+		$dialog_connection.find('.input-local-path').val(settings.localPath);
 		$dialog_connection.find('.input-server-path').val(settings.serverPath);
 		if(settings.save){
 			$dialog_connection.find('.input-save').prop('checked', true);
@@ -50,6 +51,7 @@ define(function(require) {
 		$dialog_connection.find('.input-username-p').val(settings.username_p);
 		$dialog_connection.find('.input-rsa-path-p').val(settings.rsaPath_p);
 		$dialog_connection.find('.input-password-p').val(settings.password_p);
+		$dialog_connection.find('.input-local-path').val(settings.localPath_p);
 		$dialog_connection.find('.input-server-path-p').val(settings.serverPath_p);
 		
 	}
@@ -67,6 +69,7 @@ define(function(require) {
 			username:			$dialog_connection.find('.input-username').val(),
 			rsaPath:				pathExchange($dialog_connection.find('.input-rsa-path').val(), "false", "false"),
 			password:			$dialog_connection.find('.input-password').val(),
+			localPath:			pathExchange($dialog_connection.find('.input-local-path').val(), "through", "true"),
 			serverPath:			pathExchange($dialog_connection.find('.input-server-path').val(), "through", "true"),
 			save:					$dialog_connection.find('.input-save').is(':checked'),
 			
@@ -76,6 +79,7 @@ define(function(require) {
 			username_p:			$dialog_connection.find('.input-username-p').val(),
 			rsaPath_p:			pathExchange($dialog_connection.find('.input-rsa-path-p').val(), "false", "false"),
 			password_p:			$dialog_connection.find('.input-password-p').val(),
+			localPath_p:			pathExchange($dialog_connection.find('.input-local-path-p').val(), "through", "true"),
 			serverPath_p:		pathExchange($dialog_connection.find('.input-server-path-p').val(), "through", "true")
 		};
 		

--- a/modules/SftpManager.js
+++ b/modules/SftpManager.js
@@ -111,6 +111,7 @@ define(function(require) {
 					username: connectionSetting.username,
 					rsaPath: connectionSetting.rsaPath,
 					password: connectionSetting.password,
+					localPath: connectionSetting.localPath,
 					serverPath: connectionSetting.serverPath
 				};
 			}else if(accessPoint == "production"){
@@ -122,9 +123,12 @@ define(function(require) {
 					username: connectionSetting.username_p,
 					rsaPath: connectionSetting.rsaPath_p,
 					password: connectionSetting.password_p,
+					localPath: connectionSetting.localPath_p,
 					serverPath: connectionSetting.serverPath_p
 				};
 			}
+			
+			remotePath = remotePath.replace(serverConnectionSetting.localPath, '');
 			
 			var auto = "";
 			if(uploadOnSave && !connectionSetting.save) return false;

--- a/nls/en/Strings.js
+++ b/nls/en/Strings.js
@@ -27,6 +27,7 @@ define({
 	TXT_CONNECTION_USER_NAME:	"User Name",
 	TXT_CONNECTION_PASSWORD:	"Password",
 	TXT_CONNECTION_RSA:	"RSA private key",
+	TXT_CONNECTION_LOCAL_PATH:	"Local Path",
 	TXT_CONNECTION_SERVER_PATH:	"Server Path",
 	TXT_CONNECTION_UPLOAD_ON_SAVE:	"Upload on Save",
 	TXT_CONNECTION_SETTING_LOAD:	"Reading the configuration file",


### PR DESCRIPTION
Added "Local Path" option in connection dialog. This enables us to upload files and folders relative to any directory inside project tree instead of project root.
For example, if we want to upload files from project directory "source/project-name/www/css/index.css" to remote "/www/css/index.css", then we can set Local Path to "source/project-name/www/" and remote path to "/www/".